### PR TITLE
fix form refreshing page when using enter

### DIFF
--- a/src/scripts/RecipeCardExpand.js
+++ b/src/scripts/RecipeCardExpand.js
@@ -176,6 +176,10 @@ class RecipeCardExpand extends HTMLElement {
     recipeInputFormInput.setAttribute('type', 'text');
     recipeInputForm.appendChild(recipeInputFormInput);
     recipeInputFormInput.value = searchForKey(recipeData, 'servings');
+    recipeInputForm.addEventListener('submit', function (e) { 
+      e.preventDefault();
+      saveRecipe();
+      return false; });
     recipeInputForm.classList.add('hidden');
     recipeInputFormInput.classList.add('hidden');
     recipeExpandContainer.appendChild(recipeInputForm);


### PR DESCRIPTION
Closes #124 

Makes it so pressing enter after entering new serving size will change ingredients and not refresh the page.